### PR TITLE
chore(tsconfig): enable vue-tsc v3 strict options

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -25,6 +25,12 @@
     "esModuleInterop": true,
     "types": ["chrome"]
   },
+  "vueCompilerOptions": {
+    "strictSlotChildren": true,
+    "strictVModel": true,
+    "strictCssModules": true,
+    "resolveStyleImports": true
+  },
   "include": [
     "src/**/*.ts",
     "src/**/*.d.ts",


### PR DESCRIPTION
## Summary
- Enable the new `vueCompilerOptions` introduced in vue-tsc v3: `strictSlotChildren`, `strictVModel`, `strictCssModules`, `resolveStyleImports`
- All four pass the existing codebase without any source changes, so this is pure tightening of the type-check surface

## Test plan
- [x] `pnpm build` (runs `vue-tsc -b --force`)
- [x] `pnpm lint`
- [x] `pnpm test -- run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)